### PR TITLE
Fixed issue with multiple inventory paths

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"text/template"
@@ -54,6 +56,30 @@ func TestRenderTemplate(t *testing.T) {
 
 	if !strings.Contains(string(b), "Config = ") {
 		t.Fatalf("expected: Config = , got: %v", b)
+	}
+}
+
+func TestInventory(t *testing.T) {
+	inventory := ""
+	paths := strings.Split("test1.yaml,test2.yaml", ",")
+	data := []byte("---\n...")
+
+	for i, p := range paths {
+		tp := filepath.Join(tmpDir, p)
+		if !extractToFile(tp, data, 0o440) {
+			t.Errorf("failed to create file '%s'", tp)
+			continue
+		}
+
+		sfmt := ",%s"
+		if i == 0 {
+			sfmt = "%s"
+		}
+
+		inventory += fmt.Sprintf(sfmt, tp)
+		if _, err := checkInventoryStatus(inventory, tmpDir); err != nil {
+			t.Fatalf("failed to checkInventoryStatus for '%s'", inventory)
+		}
 	}
 }
 


### PR DESCRIPTION
The code was making sure that the inventory is a valid path, which fails when multiple inventory paths are used; Ansible supports the use of multiple inventories in the format "file1,file2,dir1" etc.

* Added `checkInventoryStatus` that performs the necessary checks on the path(s) that the Ansible inventory has been set to use, removing invalid ones and creating a default one should none be usable.
* Added `TestInventory` to perform unit test on the `checkInventoryStatus` logic