### PR TITLE
Avoid passing --inventory to ansible-playbook

### DIFF
--- a/main.go
+++ b/main.go
@@ -159,7 +159,9 @@ func main() {
 		inventory = newPath
 	}
 
-	playArgs = append(playArgs, "--inventory", inventory)
+	if os.Getenv("ANSIBLE_INVENTORY") == "" || !strings.Contains(inventory, ",") {
+		playArgs = append(playArgs, "--inventory", inventory)
+	}
 
 	extractToFile(Ansible, pex, 0o550)
 	extractToFile(DynamicInventoryScript, dynamicInventory, 0o550)


### PR DESCRIPTION
Ansible does not accept a comma-delimited set of paths for `--inventory` unlike its support in `ANSIBLE_INVENTORY`, which causes issues.

* Fixed issue with multiple inventories by only appending the `--inventory` argument to `ansible-playbook` when `ANSIBLE_INVENTORY` is not set, or the passed path does not contain a comma