### PR TITLE
GAS-91 Fix CentOS Stream9 builds

### DIFF
--- a/scripts/ansible/init.sh
+++ b/scripts/ansible/init.sh
@@ -31,9 +31,17 @@ function setup_debian {
 }
 
 function setup_redhat {
+    local -a packages
+    local -a repos
+
     dnf makecache -y
-    dnf install -y python38 python38-wheel \
-                   python39 python39-wheel
+
+    case "${DISTRO}" in
+        "centos:stream8") packages=( python38 python38-wheel python39 python39-wheel );;
+        "centos:stream9") packages=( python3 python-wheel-wheel ); repos=( "--enablerepo=crb" );
+    esac
+
+    dnf install -y "${repos[@]}" "${packages[@]}"
     dnf clean all
 }
 


### PR DESCRIPTION
The script used to generate a CentOS Stream 9 base image has been updated to avoid package issues.

* Only Python 3.9 is available for CentOS Stream 9
* CRB repository is required to be able to install python-wheel