### PR TITLE
Improve distro-specific builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,9 +14,15 @@ name: "CodeQL"
 on:
   push:
     branches: [ "main" ]
+    paths:
+    - '**.go'
+    - '**.py'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "main" ]
+    paths:
+    - '**.go'
+    - '**.py'
   schedule:
     - cron: '16 23 * * 0'
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ SHELL=/bin/bash
 
 # Options
 ARCH?=amd64
+AUTH_FIELD_1?=Auth-Id
+AUTH_FIELD_2?=Auth-Token
+AUTH_FIELD_3?=Monitor-Name
 BUILD_BASE?=quay.io/centos/centos:stream8
 BUILD_DIR?=./build
 ENTRYPOINT?=pmm-full.yaml
@@ -15,7 +18,7 @@ GOFMT?=$(shell which gofumpt 2>&1)
 GOLINT?=$(shell which golint 2>&1)
 NAME?=gascan
 OS?=linux
-PY?=3.8
+PY?=3.9
 VERSION?=$(shell git rev-parse HEAD)
 
 # Constants
@@ -31,8 +34,8 @@ INSTALL_GO_LINTER:=$(shell test "${GOLINT/which: no/}" = "${GOLINT}" && echo 0 |
 REQUIRES_GO_LINTING:=$(shell test "$(GIT_BRANCH_FILES)" = "" && echo 0 || echo 1)
 #
 
+init: prep
 init:
-	@install -d "${BUILD_DIR}/${OS}/${ARCH}"
 ifeq ($(INSTALL_GO_FORMATTER), 1)
 	@cd ~ && "${GO}" install mvdan.cc/gofumpt@latest
 endif
@@ -44,17 +47,18 @@ all: ansible build
 
 ansible: ansible_image ansible_pex
 
+ansible_image: export VNAME=${NAME}/${BUILD_BASE_TAG}-ansible:${VERSION}
 ansible_image:
-	@podman image rm "${NAME}-ansible:${VERSION}" || true
+	@podman image exists "${VNAME}" && podman image rm "${VNAME}" || true
 	@buildah bud -f images/ansible/Containerfile --build-arg BASE="${BUILD_BASE}" \
-	  --squash --no-cache --force-rm --compress --tag "${NAME}-ansible:${VERSION}"
-	podman image tag "${NAME}-ansible:${VERSION}" "${NAME}-ansible:${BUILD_BASE_TAG}"
+	  --squash --no-cache --force-rm --compress --tag "${VNAME}"
 
+ansible_pex: export VDIR=${BUILD_DIR}/${OS}/${ARCH}/${BUILD_BASE_TAG}
+ansible_pex: export VNAME=${NAME}/${BUILD_BASE_TAG}-ansible:${VERSION}
 ansible_pex: prep
-	@podman run --rm -it -v "${BUILD_DIR}/${OS}/${ARCH}":/app:Z "${NAME}-ansible:${VERSION}" "${PY}"
-	@podman image rm "${NAME}-ansible:${VERSION}" || true
-	@rm -rf "${BUILD_DIR}/${OS}/${ARCH}/venv"
-	@cp -a "${BUILD_DIR}/${OS}/${ARCH}/ansible${PY}" "${BUILD_DIR}/ansible"
+	@podman run --rm -it -v "${VDIR}":/app:Z "${VNAME}" "${PY}"
+	@rm -rf "${VDIR}/venv"
+	@cp -a "${VDIR}/ansible${PY}" "${BUILD_DIR}/ansible"
 
 automation_lint:
 	@venv/bin/ansible-lint --project-dir automation --write
@@ -62,17 +66,20 @@ automation_lint:
 
 build: export GOOS=${OS}
 build: export GOARCH=${ARCH}
-build: export VNAME=${NAME}-py${PY}
+build: export VDIR=${BUILD_DIR}/${OS}/${ARCH}/${BUILD_BASE_TAG}
+build: export VNAME=${VDIR}/${NAME}-py${PY}
 build: build_prep pack check
-	@go build -o "${BUILD_DIR}/${GOOS}/${GOARCH}/${VNAME}" -trimpath -race -gcflags="all=-N -l" -ldflags="-X main.EntryPointPlaybook=${ENTRYPOINT}"
-	@cp -a "${BUILD_DIR}/${GOOS}/${GOARCH}/${VNAME}" "${BUILD_DIR}/gascan"
+	@go build -o "${VNAME}" -trimpath -race -gcflags="all=-N -l" \
+		-ldflags="-X main.EntryPointPlaybook=${ENTRYPOINT} -X main.HeaderIdentifier=${AUTH_FIELD_1} -X main.HeaderToken=${AUTH_FIELD_2} -X main.HeaderMonitorName=${AUTH_FIELD_3}"
+	@cp -a "${VNAME}" "${BUILD_DIR}/gascan"
 
 build_prep: export GOOS=${OS}
 build_prep: export GOARCH=${ARCH}
-build_prep: export VNAME=${NAME}-py${PY}
+build_prep: export VDIR=${BUILD_DIR}/${OS}/${ARCH}/${BUILD_BASE_TAG}
+build_prep: export VNAME=${VDIR}/ansible${PY}
 build_prep:
 	@rm -vf "${BUILD_DIR}/gascan"
-	@cp -a "${BUILD_DIR}/${GOOS}/${GOARCH}/ansible${PY}" "${BUILD_DIR}/ansible"
+	@cp -a "${VNAME}" "${BUILD_DIR}/ansible"
 
 check: export GOOS=${OS}
 check: export GOARCH=${ARCH}
@@ -114,6 +121,9 @@ else
 	@echo Copying custom bundle "${BUNDLE}"
 	@cp -a "${BUNDLE}" bundle.tgz
 endif
+
+prep:
+	@install -d "${BUILD_DIR}/${OS}/${ARCH}/${BUILD_BASE_TAG}"
 
 sample-bundle:
 	@git archive --output=sample-bundle.tgz --format=tar.gz "${VERSION}" automation/{pmm-server-custom.yaml,ping.yaml,templates,roles,group_vars,host_vars} scripts/dynamic-inventory/get_inventory.py

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ PY?=3.8
 VERSION?=$(shell git rev-parse HEAD)
 
 # Constants
+BUILD_BASE_TAG:=$(shell echo "${BUILD_BASE}" | sed 's^.*/^^g; s/:/-/g' | cut -f2 -d'/')
 GIT_BRANCH_FILES:=$(shell (git diff-tree --no-commit-id --name-only -r main..HEAD; git diff --name-only --diff-filter=AM HEAD) | grep -F .go)
 PACKAGE:=$(shell grep -E ^module go.mod | cut -f2 -d' ')
 VETFLAGS=( -unusedresult -bools -copylocks -framepointer -httpresponse -json -stdmethods -printf -stringintconv -unmarshal -unsafeptr )
@@ -47,6 +48,7 @@ ansible_image:
 	@podman image rm "${NAME}-ansible:${VERSION}" || true
 	@buildah bud -f images/ansible/Containerfile --build-arg BASE="${BUILD_BASE}" \
 	  --squash --no-cache --force-rm --compress --tag "${NAME}-ansible:${VERSION}"
+	podman image tag "${NAME}-ansible:${VERSION}" "${NAME}-ansible:${BUILD_BASE_TAG}"
 
 ansible_pex: prep
 	@podman run --rm -it -v "${BUILD_DIR}/${OS}/${ARCH}":/app:Z "${NAME}-ansible:${VERSION}" "${PY}"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Usage of gascan:
         Just extract the bundle, use with --extract-path
   -extract-path string
         Extract the bundle to this path, use with --extract-bundle, when TMPDIR cannot execute, etc (default "/tmp")
+  -generate-hash
+        Generate a sha256 time-based hash
   -inventory string
         Set a custom inventory
   -log-level string
@@ -205,13 +207,14 @@ $ gascan --monitor=dummy-monitor
 
 The following options apply to all of the builds:
 * `ARCH` sets the system archiecture, currently limited to `amd64`
+* `BUILD_DIR` sets the base output directory for the Go binaries
 * `BUNDLE` when set will use a custom tarball instead of generating one
 * `OS` sets the operating system, currently limited to `linux`
 * `VERSION` sets the tag for container images and builds
 
-Executable files are generated to "${BUILD_DIR}/${OS}/${ARCH}", e.g:
+Executable files are generated to "${BUILD_DIR}/${OS}/${ARCH}/${BUILD_BASE_TAG}", e.g:
 ```sh
-$ ls -1 build/linux/amd64
+$ ls -1 build/linux/amd64/centos-stream8
 ansible3.8
 gascan-py3.8
 ```
@@ -227,6 +230,13 @@ For ease, the latest generated `gascan` binary can be found at "${BUILD_DIR}/gas
 * `GO` sets the Golang version
 * `GOFMT` sets the formatting tool
 * `GOLINT` sets the linter
+
+There are some additional build variables that have an effect on the generation of the
+sample config for the dynamic inventory script, which is generated via the `--extract-bundle`
+option:
+* `AUTH_FIELD_1` sets the first header used, default `Auth-Id`
+* `AUTH_FIELD_2` sets the second header used, default `Auth-Token`
+* `AUTH_FIELD_3` sets the final header used, default `Monitor-Name`
 
 ### Examples
 

--- a/images/ansible/Containerfile
+++ b/images/ansible/Containerfile
@@ -1,15 +1,22 @@
-ARG BASE=quay.io/centos/centos:stream8
+ARG ANSIBLE=6.6.0
+ARG BASE=quay.io/centos/centos:stream9
+ARG PACKAGES_OS=
+ARG PACKAGES_PIP=
 ARG USER_NAME=percona
 ARG USER_UID=1000
 
 FROM "${BASE}"
 
+ARG ANSIBLE
 ARG BASE
+ARG PACKAGES_OS
+ARG PACKAGES_PIP
 COPY scripts /opt/scripts
-RUN /opt/scripts/ansible/init.sh "$(basename "${BASE}")"
+COPY extra_packages*txt /opt
+RUN /opt/scripts/ansible/init.sh "$(basename "${BASE}")" "${PACKAGES_OS}"
 
 USER "${USER_NAME}"
 WORKDIR /app
 ENTRYPOINT ["/opt/scripts/ansible/install.sh"]
-CMD ["3.8"]
+CMD ["3.9", "${ANSIBLE}", "${PACKAGES_PIP}"]
 VOLUME ["/app"]

--- a/os_test.go
+++ b/os_test.go
@@ -11,7 +11,7 @@ import (
 
 func generateDummyTarball() ([]byte, error) {
 	var buf bytes.Buffer
-	var files = []struct {
+	files := []struct {
 		Name, Body string
 		Mode       int64
 	}{

--- a/scripts/ansible/init.sh
+++ b/scripts/ansible/init.sh
@@ -6,6 +6,7 @@
 set -eu
 
 declare -r DISTRO="${1}"
+declare -r PACKAGES="${2:-undef}"
 
 declare USERNAME="${USER_NAME:-percona}"
 declare -i USERUID=${USER_UID:-1000}
@@ -16,29 +17,45 @@ function setup {
     case "${DISTRO}" in
         # TODO: add support for UBI - ubi, ubi-minimal, ubi-init
         ## https://developers.redhat.com/products/rhel/ubi
-        "centos:stream8"|"centos:stream9") setup_redhat;;
-        "centos:7") setup_redhat_legacy;;
-        "ubuntu:22.04"|"ubuntu:jammy"|"debian:bullseye"|"debian:11") setup_debian;;
-        "python:3.10-slim") ;;
+        "centos:stream8"|"centos:stream9") setup_redhat "${@}";;
+        "centos:7") setup_redhat_legacy "${@}";;
+        "ubuntu:22.04"|"ubuntu:jammy"|"debian:bullseye"|"debian:11") setup_debian "${@}";;
+        #"python:3.10-slim") ;;
         *) echo "Unsupported distro: ${DISTRO}"; exit 1
     esac
 }
 
 function setup_debian {
+    local -r extra_packages="${1}"
+    local -a packages
+
+    if [ -f "${extra_packages}" ]; then
+        mapfile -t packages < "${extra_packages}"
+    fi
+
+    case "${DISTRO}" in
+        *) packages+=( python3-minimal python3-venv )
+    esac
+
     apt update -qqy
-    apt install -qqy python3-minimal python3-venv
+    apt install -qqy "${packages[@]}"
     apt clean -qqy
 }
 
 function setup_redhat {
+    local -r extra_packages="${1}"
     local -a packages
     local -a repos
+
+    if [ -f "${extra_packages}" ]; then
+        mapfile -t packages < "${extra_packages}"
+    fi
 
     dnf makecache -y
 
     case "${DISTRO}" in
-        "centos:stream8") packages=( python38 python38-wheel python39 python39-wheel );;
-        "centos:stream9") packages=( python3 python-wheel-wheel ); repos=( "--enablerepo=crb" );
+        "centos:stream8") packages+=( python38 python38-wheel python39 python39-wheel );;
+        "centos:stream9") packages+=( python3 python-wheel-wheel ); repos=( "--enablerepo=crb" );
     esac
 
     dnf install -y "${repos[@]}" "${packages[@]}"
@@ -46,9 +63,20 @@ function setup_redhat {
 }
 
 function setup_redhat_legacy {
+    local -r extra_packages="${1}"
+    local -a packages
+
+    if [ -f "${extra_packages}" ]; then
+        mapfile -t packages < "${extra_packages}"
+    fi
+
+    case "${DISTRO}" in
+        *) packages+=( rh-python38 rh-python38-python-wheel )
+    esac
+
     yum makecache -y
     yum install -y centos-release-scl
-    yum install -y rh-python38 rh-python38-python-wheel
+    yum install -y "${packages[@]}"
     yum clean all
     update-alternatives --install /usr/bin/python3.8 python3.8 /opt/rh/rh-python38/root/bin/python3.8 100
 }
@@ -60,4 +88,4 @@ id -un "${USERUID}" || {
         "${USERNAME}"
 }
 
-setup
+setup "${PACKAGES}"

--- a/scripts/ansible/install.sh
+++ b/scripts/ansible/install.sh
@@ -5,8 +5,9 @@
 # PEX_UNZIP=1 PEX_ROOT=/tmp/foo ./ansible3.8 --help
 set -eu
 
-declare VERSION="${1:-3.8}"
-declare ANSIBLE="${2:-5.6.0}"
+declare VERSION="${1:-3.9}"
+declare ANSIBLE="${2:-6.6.0}"
+declare -r PACKAGES="${3:-undef}"
 declare -r REQUIREMENTS='/tmp/requirements.txt'
 
 function build_pex {
@@ -18,6 +19,11 @@ ansible==${ANSIBLE}
 jmespath
 dnspython
 EOS
+
+if [ -f "/opt/${PACKAGES}" ]; then
+    cat "/opt/${PACKAGES}" >> "${REQUIREMENTS}"
+    rm -f "/opt/${PACKAGES}"
+fi
 
 "/usr/bin/python${VERSION}" -m venv --clear /app/venv
 "/app/venv/bin/pip${VERSION}" install --quiet --upgrade pip pex wheel


### PR DESCRIPTION
Whilst the existing code does not prohibit generating a build using a specific base distro, it is less than optimal.

* Added `BUILD_BASE_TAG` to allow persistent generation of specific base images and updated the relevant `Makefile` commands to generate distro-and-Python-specific binaries
* Update the README