### PR TITLE
Simplify building all default versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ GOFMT?=$(shell which gofumpt 2>&1)
 GOLINT?=$(shell which golint 2>&1)
 NAME?=gascan
 OS?=linux
-PACKAGES_OS?=extra_packages_os.txt
-PACKAGES_PIP?=extra_packages_pip.txt
+PACKAGES_OS?=images/ansible/extra_packages_os.txt
+PACKAGES_PIP?=images/ansible/extra_packages_pip.txt
 PY?=3.9
 VERSION?=$(shell git rev-parse HEAD)
 
@@ -47,6 +47,34 @@ ifeq ($(INSTALL_GO_LINTER), 1)
 endif
 
 all: ansible build 
+
+all_versions:
+	@printf "all_el9\nall_el8\nall_el7\nall_jammy\nall_bullseye"
+
+all_el9: export BUILD_BASE=quay.io/centos/centos:stream9
+all_el9: export BUILD_BASE_TAG=centos-stream9
+all_el9: export PY=3.9
+all_el9: ansible build
+
+all_el8: export BUILD_BASE=quay.io/centos/centos:stream8
+all_el8: export BUILD_BASE_TAG=centos-stream8
+all_el8: export PY=3.9
+all_el8: ansible build
+
+all_el7: export BUILD_BASE=quay.io/centos/centos:7
+all_el7: export BUILD_BASE_TAG=centos-7
+all_el7: export PY=3.8
+all_el7: ansible build
+
+all_jammy: export BUILD_BASE=ubuntu:jammy
+all_jammy: export BUILD_BASE_TAG=ubuntu-jammy
+all_jammy: export PY=3.10
+all_jammy: ansible build
+
+all_bullseye: export BUILD_BASE=debian:bullseye
+all_bullseye: export BUILD_BASE_TAG=debian-bullseye
+all_bullseye: export PY=3.9
+all_bullseye: ansible build
 
 ansible: ansible_image ansible_pex
 

--- a/README.md
+++ b/README.md
@@ -242,12 +242,17 @@ option:
 
 #### Standard build
 ```sh
-# Build everything
+# Build everything for the default version
 $ make all
 
 # Build separately
 $ make ansible
 $ make build
+```
+
+#### Build all versions
+```sh
+$ make all_versions | xargs -L1 make
 ```
 
 #### Build for Python 3.9

--- a/images/ansible/Containerfile
+++ b/images/ansible/Containerfile
@@ -12,7 +12,7 @@ ARG BASE
 ARG PACKAGES_OS
 ARG PACKAGES_PIP
 COPY scripts /opt/scripts
-COPY images/ansible/extra_packages_*.txt /opt
+COPY "${PACKAGES_OS}" "${PACKAGES_PIP}" /opt
 RUN /opt/scripts/ansible/init.sh "$(basename "${BASE}")" "${PACKAGES_OS}"
 
 USER "${USER_NAME}"

--- a/images/ansible/Containerfile
+++ b/images/ansible/Containerfile
@@ -12,7 +12,7 @@ ARG BASE
 ARG PACKAGES_OS
 ARG PACKAGES_PIP
 COPY scripts /opt/scripts
-COPY extra_packages*txt /opt
+COPY images/ansible/extra_packages_*.txt /opt
 RUN /opt/scripts/ansible/init.sh "$(basename "${BASE}")" "${PACKAGES_OS}"
 
 USER "${USER_NAME}"

--- a/images/ansible/extra_packages_pip.txt
+++ b/images/ansible/extra_packages_pip.txt
@@ -1,0 +1,1 @@
+passlib

--- a/scripts/ansible/init.sh
+++ b/scripts/ansible/init.sh
@@ -88,4 +88,4 @@ id -un "${USERUID}" || {
         "${USERNAME}"
 }
 
-setup "${PACKAGES}"
+setup "/opt/$(basename "${PACKAGES}")"

--- a/scripts/ansible/install.sh
+++ b/scripts/ansible/install.sh
@@ -5,8 +5,8 @@
 # PEX_UNZIP=1 PEX_ROOT=/tmp/foo ./ansible3.8 --help
 set -eu
 
-declare VERSION="${1:-3.9}"
-declare ANSIBLE="${2:-6.6.0}"
+declare -r VERSION="${1:-3.9}"
+declare -r ANSIBLE="${2:-6.6.0}"
 declare -r PACKAGES="${3:-undef}"
 declare -r REQUIREMENTS='/tmp/requirements.txt'
 
@@ -14,18 +14,20 @@ function build_pex {
     /app/venv/bin/pex -r "${REQUIREMENTS}" -c ansible -o "/app/ansible${VERSION}" -- --help
 }
 
-cat <<EOS > "${REQUIREMENTS}"
-ansible==${ANSIBLE}
-jmespath
-dnspython
-EOS
+function prep {
+    local -ar requirements=( "ansible==${ANSIBLE}" "jmespath" "dnspython" )
+    local -r extra_packages="${1}"
 
-if [ -f "/opt/${PACKAGES}" ]; then
-    cat "/opt/${PACKAGES}" >> "${REQUIREMENTS}"
-    rm -f "/opt/${PACKAGES}"
-fi
+    printf "%s\n%s\n%s\n" "${requirements[@]}" > "${REQUIREMENTS}"
 
-"/usr/bin/python${VERSION}" -m venv --clear /app/venv
-"/app/venv/bin/pip${VERSION}" install --quiet --upgrade pip pex wheel
+    if [ -f "/opt/${extra_packages}" ]; then
+        cat "/opt/${extra_packages}" >> "${REQUIREMENTS}"
+        rm -f "/opt/${extra_packages}"
+    fi
 
+    "/usr/bin/python${VERSION}" -m venv --clear /app/venv
+    "/app/venv/bin/pip${VERSION}" install --quiet --upgrade pip pex wheel
+}
+
+prep "$(basename "${PACKAGES}")"
 build_pex


### PR DESCRIPTION
Whilst it is possible to use the environment variables to control the
builds, adding the defaults as commands makes life easy sparkles

* Added `all_versions` command that can be used to see all of the
  default versions. This can then be used along with `xargs` and you can
  make each one of them in series
* Added `all_*` commands for `el9`, `el8`, `el7`, `jammy` and `bullseye`
* Update `README` with examples
* Added `passlib` as a default in `extra_packages_pip.txt`