### PR TITLE
Add version information

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -26,6 +27,14 @@ type Flags struct {
 // EntryPointPlaybook defines the playbook that is executed at runtime
 var EntryPointPlaybook = "pmm-full.yaml"
 
+func printVersion() {
+	fmt.Println("Version:", Version)
+	fmt.Println("Go Version:", runtime.Version())
+	fmt.Println("Arch:", runtime.GOOS, runtime.GOARCH)
+	fmt.Println("Ansible Version:", AnsibleVersion)
+	fmt.Println("Python Version:", PythonVersion)
+}
+
 func flags() {
 	Config.Mode = 0
 
@@ -43,6 +52,7 @@ func flags() {
 	noConfigFlag := flag.Bool("skip-configure", false, "Skip initial configuration")
 	noDeployFlag := flag.Bool("skip-deploy", false, "Skip deploying the monitor host")
 	testFlag := flag.Bool("test", false, "Run the test play (ping)")
+	versionFlag := flag.Bool("version", false, "Show the version")
 
 	flag.BoolVar(&Config.NoSudoPassword, "passwordless-sudo", !needsBecomePass, "The use of sudo does not require a password")
 
@@ -74,6 +84,11 @@ func flags() {
 	}
 
 	flag.Parse()
+
+	if *versionFlag {
+		printVersion()
+		os.Exit(0)
+	}
 
 	if *generateHashFlag {
 		hash, err := generateHash("/etc/machine-id")

--- a/generate.go
+++ b/generate.go
@@ -1,0 +1,47 @@
+//go:build ignore
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+const versionGo = `// Code generated .* DO NOT EDIT\.
+package main
+
+const (
+    // AnsibleVersion for the built-in PEX
+    AnsibleVersion = "%s"
+
+    // PythonVersion for the built-in PEX
+    PythonVersion = "%s"
+
+    // Version of the software, determined by env RELEASE_VERSION
+    Version = "%s"
+)
+`
+
+func main() {
+	ansible_version := strings.ReplaceAll(os.Getenv("ANSIBLE_VERSION"), `"`, "")
+	python_version := strings.ReplaceAll(os.Getenv("PYTHON_VERSION"), `"`, "")
+	version := strings.ReplaceAll(os.Getenv("RELEASE_VERSION"), `"`, "")
+
+	if ansible_version == "" {
+		panic("env ANSIBLE_VERSION is undefined")
+	}
+
+	if python_version == "" {
+		panic("env PYTHON_VERSION is undefined")
+	}
+
+	if version == "" {
+		panic("env RELEASE_VERSION is undefined")
+	}
+
+	if err := ioutil.WriteFile("version.go", []byte(fmt.Sprintf(versionGo, ansible_version, python_version, version)), 0o644); err != nil {
+		panic("unable to write version.go")
+	}
+}

--- a/generate_version.go
+++ b/generate_version.go
@@ -1,0 +1,2 @@
+//go:generate go run generate.go
+package main


### PR DESCRIPTION
* Added `--version` flag, `cli.printVersion` to print out the gascan, Ansible, Python and Go versions used at build time
* Added `generate.go` and `generate_version.go` to dynamically generate `version.AnsibleVersion`, `version.PythonVersion` and `version.Version`
* Update `Makefile` to automatically call `go generate` for all relevant tasks