### PR TITLE
Automation sync

### DIFF
--- a/automation/pmm-full.yaml
+++ b/automation/pmm-full.yaml
@@ -2,18 +2,18 @@
 - name: PMM Server
   ansible.builtin.import_playbook: pmm-server.yaml
   tags:
-  - pmm
-  - server
+    - pmm
+    - server
 
 - name: Tooling
   ansible.builtin.import_playbook: tools.yaml
   tags:
-  - tools
-  - server
+    - tools
+    - server
 
 - name: PMM Client
   ansible.builtin.import_playbook: pmm-client.yaml
   tags:
-  - pmm
-  - client
+    - pmm
+    - client
 ...

--- a/automation/roles/pmm/tasks/client.yaml
+++ b/automation/roles/pmm/tasks/client.yaml
@@ -38,7 +38,7 @@
 
     - name: Setup pmm-agent bypassing registration
       ansible.builtin.command:
-        cmd: '{{ pmm_client_extract_base }}/pmm/bin/pmm-agent setup --id={{ pmm_agent_info.agent_id }} --skip-registration @${HOME}/.config/pmm/agent-flags.txt'
+        cmd: '{{ pmm_client_extract_base }}/pmm/bin/pmm-agent setup --id={{ pmm_inventory_pmm_agent_id }} --skip-registration @${HOME}/.config/pmm/agent-flags.txt'
       when: ("If you want override node, use --force option" in pmm_agent_setup_command.stdout) and pmm_agent_running_node_exporter|length
 
     - name: Validate setup

--- a/automation/roles/tools/defaults/main.yaml
+++ b/automation/roles/tools/defaults/main.yaml
@@ -24,6 +24,16 @@ tools_mysql_versions:
   - 5.7
   - 8.0
 
+tools_postgresql_conf: "{{ ansible_env.HOME }}/.pgpass"
+tools_postgresql_image: docker.io/perconalab/percona-distribution-postgresql
+tools_postgresql_install: "{{ 'postgresql' in groups and groups['postgresql'] | length > 0 }}"
+tools_postgresql_versions:
+  - 11.18
+  - 12.13
+  - 13.9
+  - 14.6
+  - 15.1
+
 tools_profile_path: "{{ tools_home_dir }}/.bashrc"
 
 tools_user_bin_dir: "{{ tools_home_dir }}/bin"

--- a/automation/roles/tools/tasks/main.yaml
+++ b/automation/roles/tools/tasks/main.yaml
@@ -23,6 +23,15 @@
   tags:
     - mysql
 
+- name: Install PostgreSQL clients
+  ansible.builtin.include_tasks: postgresql-client.yaml
+  vars:
+    tools_postgresql_image_tag: '{{ item }}'
+  loop: '{{ tools_postgresql_versions }}'
+  when: tools_postgresql_install
+  tags:
+    - postgresql
+
 - name: Include distro specific variables
   ansible.builtin.include_vars: '{{ ansible_distribution | lower }}.yaml'
 

--- a/automation/roles/tools/tasks/postgresql-client.yaml
+++ b/automation/roles/tools/tasks/postgresql-client.yaml
@@ -1,0 +1,28 @@
+---
+- name: Prepare the PostgreSQL container image
+  ansible.builtin.include_role:
+    name: container
+  vars:
+    container_image: '{{ tools_postgresql_image }}:{{ tools_postgresql_image_tag }}'
+
+- name: Check for tools_postgresql_conf
+  ansible.builtin.stat:
+    path: '{{ tools_postgresql_conf }}'
+  register: tools_stat_postgresql_conf
+
+- name: Ensure that the mounted files exist
+  ansible.builtin.copy:
+    dest: '{{ tools_postgresql_conf }}'
+    content: >
+      # This file is unmanaged
+    mode: u=rw,g=r,o=
+  when: not tools_stat_postgresql_conf.stat.exists
+
+- name: Add alias for PostgreSQL CLI
+  ansible.builtin.lineinfile:
+    path: '{{ tools_profile_path }}'
+    create: yes
+    line: "alias psql{{ tools_postgresql_image_tag }}='podman run --rm -it --entrypoint=psql -v {{ tools_postgresql_conf }}:/home/postgres/{{ tools_postgresql_conf | basename }}:z {{ tools_postgresql_image }}:{{ tools_postgresql_image_tag }}'"
+    owner: '{{ ansible_env.USER }}'
+    mode: u=rw,g=r,o=
+...


### PR DESCRIPTION
Squashed 'automation/' changes from 05576a5..fca3e4d

fca3e4d GAS-234: pmm_agent_info is undefined (https://github.com/cezmunsta/gascan/pull/18)
833e4ae GAS-169: Add PostgreSQL tools (https://github.com/cezmunsta/gascan/pull/16)
6097600 GAS-166: PostgreSQL socket path should be a directory
a0a14d6 GAS-144: Gascan needs two run to setup alerting (https://github.com/cezmunsta/gascan/pull/13)
89fba86 Added env to PR workflow full-run job
49659b2 GAS-130: Clean up YAML lints (https://github.com/cezmunsta/gascan/pull/12)
cc7b438 Review code to ensure Ansible FQCNs are used (https://github.com/cezmunsta/gascan/pull/10)
3a12905 GAS-114 Start PMM server on boot (https://github.com/cezmunsta/gascan/pull/9)
8c88b72 Added inventory for PR workflows
e409cfb Fixed connections in inventory for PR workflow
c6cf4e8 Updated PR worflow to run in full
65244ea Added initial workflow
17067f6 GAS-115 Allow the default PMM credentials to be used (https://github.com/cezmunsta/gascan/pull/8)

git-subtree-dir: automation
git-subtree-split: fca3e4da61c1ad76bfb9b01fe61b08c1fdf10ab4