### PR TITLE
GAS-276 Bundle version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,14 @@ SHELL=/bin/bash
 .PHONY: venv
 
 # Options
-ANSIBLE?=6.6.0
+ANSIBLE?=6.7.0
 ARCH?=amd64
 AUTH_FIELD_1?=Auth-Id
 AUTH_FIELD_2?=Auth-Token
 AUTH_FIELD_3?=Monitor-Name
 BUILD_BASE?=quay.io/centos/centos:stream8
 BUILD_DIR?=./build
+BUNDLE_VERSION?=$(shell git rev-parse HEAD)
 ENTRYPOINT?=pmm-full.yaml
 GO?=$(shell which go)
 GOFMT?=$(shell which gofumpt 2>&1)
@@ -130,6 +131,7 @@ test: go_generate check
 	@rm -f version.go
 
 go_generate: export ANSIBLE_VERSION="${ANSIBLE}"
+go_generate: export BUNDLE_RELEASE_VERSION="${BUNDLE_VERSION}"
 go_generate: export PYTHON_VERSION="${PY}"
 go_generate: export RELEASE_VERSION="${VERSION}"
 go_generate:
@@ -177,4 +179,4 @@ sample-bundle:
 venv:
 	@python3 -m venv venv
 	@venv/bin/pip install -U pip wheel
-	@venv/bin/pip install -U ansible==5.6.0 jmespath dnspython ansible-lint
+	@venv/bin/pip install -U ansible=="${ANSIBLE}" jmespath dnspython ansible-lint

--- a/cli.go
+++ b/cli.go
@@ -32,6 +32,7 @@ func printVersion() {
 	fmt.Println("Go Version:", runtime.Version())
 	fmt.Println("Arch:", runtime.GOOS, runtime.GOARCH)
 	fmt.Println("Ansible Version:", AnsibleVersion)
+	fmt.Println("Bundle Version:", BundleVersion)
 	fmt.Println("Python Version:", PythonVersion)
 }
 

--- a/generate.go
+++ b/generate.go
@@ -16,6 +16,9 @@ const (
     // AnsibleVersion for the built-in PEX
     AnsibleVersion = "%s"
 
+    // BundleVersion for the built-in bundle, determined by env BUNDLE_VERSION
+    BundleVersion = "%s"
+
     // PythonVersion for the built-in PEX
     PythonVersion = "%s"
 
@@ -25,15 +28,20 @@ const (
 `
 
 func main() {
-	ansible_version := strings.ReplaceAll(os.Getenv("ANSIBLE_VERSION"), `"`, "")
-	python_version := strings.ReplaceAll(os.Getenv("PYTHON_VERSION"), `"`, "")
+	ansibleVersion := strings.ReplaceAll(os.Getenv("ANSIBLE_VERSION"), `"`, "")
+	bundleVersion := strings.ReplaceAll(os.Getenv("BUNDLE_RELEASE_VERSION"), `"`, "")
+	pythonVersion := strings.ReplaceAll(os.Getenv("PYTHON_VERSION"), `"`, "")
 	version := strings.ReplaceAll(os.Getenv("RELEASE_VERSION"), `"`, "")
 
-	if ansible_version == "" {
+	if ansibleVersion == "" {
 		panic("env ANSIBLE_VERSION is undefined")
 	}
 
-	if python_version == "" {
+	if bundleVersion == "" {
+		panic("env BUNDLE_RELEASE_VERSION is undefined")
+	}
+
+	if pythonVersion == "" {
 		panic("env PYTHON_VERSION is undefined")
 	}
 
@@ -41,7 +49,7 @@ func main() {
 		panic("env RELEASE_VERSION is undefined")
 	}
 
-	if err := ioutil.WriteFile("version.go", []byte(fmt.Sprintf(versionGo, ansible_version, python_version, version)), 0o644); err != nil {
+	if err := ioutil.WriteFile("version.go", []byte(fmt.Sprintf(versionGo, ansibleVersion, bundleVersion, pythonVersion, version)), 0o644); err != nil {
 		panic("unable to write version.go")
 	}
 }

--- a/scripts/ansible/install.sh
+++ b/scripts/ansible/install.sh
@@ -6,7 +6,7 @@
 set -eu
 
 declare -r VERSION="${1:-3.9}"
-declare -r ANSIBLE="${2:-6.6.0}"
+declare -r ANSIBLE="${2:-6.7.0}"
 declare -r PACKAGES="${3:-undef}"
 declare -r REQUIREMENTS='/tmp/requirements.txt'
 


### PR DESCRIPTION
The following information is currently available with gascan:
```
Version: 8ce0ab476b148db7198bc0be4fc956619a3af9aa
Go Version: go1.19.4
Arch: linux amd64
Ansible Version: 6.6.0
Python Version: 3.9
```

- Adding the version of the bundled automation code be added for builds where gascan itself does not change.
- Updating the default version of Ansible to 6.7.0