### PR TITLE
Added --list-plays option and --playbook checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ build
 bundle.tgz
 venv
 extract.go
+playbook.go
 version.go

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ check:
 	@echo check: No Go files to check
 endif
 
+test: export GASCAN_TEST_NOEXIT=1
 test: go_generate check
 	@${GO} test ./...
 	@rm -f version.go

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,13 @@ build: export VDIR=${BUILD_DIR}/${OS}/${ARCH}/${BUILD_BASE_TAG}
 build: export VNAME=${VDIR}/${NAME}-py${PY}
 build: export CGO_ENABLED=0
 build: build_prep pack check
+ifeq ($(DEBUG_BUILD), 1)
 	@${GO} build -o "${VNAME}" -trimpath -gcflags="all=-N -l" \
 		-ldflags="-X main.EntryPointPlaybook=${ENTRYPOINT} -X main.HeaderIdentifier=${AUTH_FIELD_1} -X main.HeaderToken=${AUTH_FIELD_2} -X main.HeaderMonitorName=${AUTH_FIELD_3}"
+else
+	@${GO} build -o "${VNAME}" -trimpath \
+		-ldflags="-s -w -X main.EntryPointPlaybook=${ENTRYPOINT} -X main.HeaderIdentifier=${AUTH_FIELD_1} -X main.HeaderToken=${AUTH_FIELD_2} -X main.HeaderMonitorName=${AUTH_FIELD_3}"
+endif
 	@cp -a "${VNAME}" "${BUILD_DIR}/gascan"
 	@rm -f version.go
 

--- a/cli.go
+++ b/cli.go
@@ -27,6 +27,20 @@ type Flags struct {
 // EntryPointPlaybook defines the playbook that is executed at runtime
 var EntryPointPlaybook = "pmm-full.yaml"
 
+func checkPlaybook(play string) {
+	exists := false
+	for _, p := range strings.Split(PlaybookList, ",") {
+		if play == p {
+			exists = true
+			break
+		}
+	}
+
+	if !exists {
+		Logger.Fatal("Playbook %s is unavailable, please use --list-plays to see what's available", play)
+	}
+}
+
 func printVersion() {
 	fmt.Println("Version:", Version)
 	fmt.Println("Go Version:", runtime.Version())
@@ -50,6 +64,7 @@ func flags() {
 
 	extractOnlyFlag := flag.Bool("extract-bundle", false, "Just extract the bundle, use with --extract-path")
 	generateHashFlag := flag.Bool("generate-hash", false, "Generate a sha256 time-based hash")
+	listPlaysFlag := flag.Bool("list-plays", false, "List the available playbooks")
 	noConfigFlag := flag.Bool("skip-configure", false, "Skip initial configuration")
 	noDeployFlag := flag.Bool("skip-deploy", false, "Skip deploying the monitor host")
 	testFlag := flag.Bool("test", false, "Run the test play (ping)")
@@ -90,6 +105,13 @@ func flags() {
 		printVersion()
 		os.Exit(0)
 	}
+
+	if *listPlaysFlag {
+		fmt.Println(strings.ReplaceAll(PlaybookList, ",", "\n"))
+		os.Exit(0)
+	}
+
+	checkPlaybook(Config.Playbook)
 
 	if *generateHashFlag {
 		hash, err := generateHash("/etc/machine-id")

--- a/generate.go
+++ b/generate.go
@@ -3,9 +3,16 @@
 package main
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	_ "embed"
+	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -21,6 +28,15 @@ const (
 	// ExtractDynamicInventory controls whether the dynamic inventory script
 	// should be extracted from the binary
 	ExtractDynamicInventory = %v
+)
+`
+	playGo = `// Code generated .* DO NOT EDIT\.
+package main
+
+const (
+	// PlaybookList is a newline-delimited list of playbooks
+	// found in the embedded tarball, avoids inspection
+	PlaybookList = "%s"
 )
 `
 	versionGo = `// Code generated .* DO NOT EDIT\.
@@ -42,7 +58,12 @@ const (
 `
 )
 
-var optInDefaultOn = map[string]bool{"": true, "yes": true, "1": true}
+var (
+	//go:embed bundle.tgz
+	bundle []byte
+
+	optInDefaultOn = map[string]bool{"": true, "yes": true, "1": true}
+)
 
 func generateVersion() {
 	ansibleVersion := strings.ReplaceAll(os.Getenv("ANSIBLE_VERSION"), `"`, "")
@@ -91,7 +112,61 @@ func generateExtract() {
 	}
 }
 
+func generatePlaybook() {
+	var plays []string
+
+	buf := bytes.NewBuffer(bundle)
+	gbuf, err := gzip.NewReader(buf)
+	if err != nil {
+		panic("unable to read with gzip")
+	}
+
+	tr := tar.NewReader(gbuf)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			panic("failed to extract tarball")
+		}
+
+		// Fail if an unexpected prefix exists, or the path ascends the directory tree
+		if strings.Contains(hdr.Name, "..") {
+			continue
+		}
+
+		pth := strings.Replace(hdr.Name, "automation/", "", 1)
+		if !strings.HasSuffix(pth, ".yaml") || strings.Contains(pth, "/") {
+			continue
+		}
+		plays = append(plays, pth)
+	}
+
+	sort.Strings(plays)
+
+	if err := ioutil.WriteFile("playbook.go", []byte(fmt.Sprintf(playGo, strings.Join(plays, ","))), 0o644); err != nil {
+		panic("unable to write extract.go")
+	}
+}
+
 func main() {
-	generateExtract()
-	generateVersion()
+	genExtractFlag := flag.Bool("generate-extract", false, "Generate extract.go")
+	genPlaybookFlag := flag.Bool("generate-playbook", false, "Generate playbook.go")
+	genVersionFlag := flag.Bool("generate-version", false, "Generate version.go")
+
+	flag.Parse()
+
+	if *genExtractFlag {
+		generateExtract()
+	}
+
+	if *genPlaybookFlag {
+		generatePlaybook()
+	}
+
+	if *genVersionFlag {
+		generateVersion()
+	}
 }

--- a/generate_extract.go
+++ b/generate_extract.go
@@ -1,0 +1,2 @@
+//go:generate go run generate.go --generate-extract
+package main

--- a/generate_playbook.go
+++ b/generate_playbook.go
@@ -1,0 +1,2 @@
+//go:generate go run generate.go --generate-playbook
+package main

--- a/generate_version.go
+++ b/generate_version.go
@@ -1,2 +1,2 @@
-//go:generate go run generate.go
+//go:generate go run generate.go --generate-version
 package main

--- a/log.go
+++ b/log.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"os"
 )
 
 const (
@@ -54,12 +55,13 @@ func (l *Log) Error(msg string, args ...interface{}) bool {
 }
 
 // Fatal messages
-func (l *Log) Fatal(msg string, args ...interface{}) bool {
+func (l *Log) Fatal(msg string, args ...interface{}) {
 	if l.Level > fatalLevel {
-		return false
+		return
 	}
 
-	return l.log(debugLevel, msg, args...)
+	l.log(debugLevel, msg, args...)
+	os.Exit(1)
 }
 
 // Info messages

--- a/log.go
+++ b/log.go
@@ -61,7 +61,10 @@ func (l *Log) Fatal(msg string, args ...interface{}) {
 	}
 
 	l.log(debugLevel, msg, args...)
-	os.Exit(1)
+
+	if os.Getenv("GASCAN_TEST_NOEXIT") != "1" {
+		os.Exit(1)
+	}
 }
 
 // Info messages


### PR DESCRIPTION
To help the user use the --playbook flag, we can generate a list of included playbooks during the build and print it out with --list-plays. We can fail earlier if an invalid playbook is includeded too.

* Updated generate.go to accept options for generation. Added in a function to generate a string containing all of the playbooks
* Added --list-plays to show the user the available playbooks
* Updated --playbook usage to trigger a check for a valid playbook as soon as the flags have been parsed.
* Fixed log.Fatal to exit
* Updated ignore list
* Updated build to strip the binary unless DEBUG is enabled