### PR TITLE
GAS-348 Set options via environment variables

### DIFF
--- a/cli_test.go
+++ b/cli_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+var envOverrideVars = map[string]string{
+	"EDITOR":                        "nano",
+	"GASCAN_FLAG_LOG_LEVEL":         "debug",
+	"GASCAN_FLAG_PASSWORDLESS_SUDO": "1",
+	"GASCAN_FLAG_PLAYBOOK":          "ping.yaml",
+	"GASCAN_FLAG_SKIP_TAGS":         "sudo",
+	"GASCAN_FLAG_TAGS":              "sudo",
+}
+
+func TestConfiguration(t *testing.T) {
+	if !checkPlaybook(EntryPointPlaybook) {
+		t.Fatalf("EntryPointPlaybook '%s' is absent from the bundle", EntryPointPlaybook)
+	}
+
+	// Test env overrides
+	for e, v := range envOverrideVars {
+		os.Setenv(e, v)
+	}
+
+	flags()
+
+	for e, v := range envOverrideVars {
+		data := map[string]interface{}{"cfg": "", "exp": ""}
+
+		switch e {
+		case "EDITOR":
+			data["cfg"] = Config.Editor
+			data["exp"] = v
+			break
+		case "GASCAN_FLAG_LOG_LEVEL":
+			data["cfg"] = Config.LogLevel
+			data["exp"] = v
+			break
+		case "GASCAN_FLAG_PASSWORDLESS_SUDO":
+			data["cfg"] = Config.NoSudoPassword
+			data["exp"] = optInDefaultOff[v]
+			break
+		case "GASCAN_FLAG_PLAYBOOK":
+			data["cfg"] = Config.Playbook
+			data["exp"] = v
+			break
+		case "GASCAN_FLAG_SKIP_TAGS":
+			data["cfg"] = Config.SkipTags
+			data["exp"] = v
+			break
+		case "GASCAN_FLAG_TAGS":
+			data["cfg"] = Config.Tags
+			data["exp"] = v
+			break
+		}
+
+		if data["cfg"] != data["exp"] {
+			t.Fatalf("%s does not match: got %v, expected %v", e, data["cfg"], data["exp"])
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -89,7 +89,8 @@ var (
 
 	isDone bool
 
-	optInDefaultOn = map[string]bool{"": true, "yes": true, "1": true}
+	optInDefaultOn  = map[string]bool{"": true, "true": true, "yes": true, "1": true}
+	optInDefaultOff = map[string]bool{"true": true, "yes": true, "1": true}
 
 	//go:embed build/ansible
 	pex []byte


### PR DESCRIPTION
Certain options are already controllable via environment vairables, such as:

* ANSIBLE_BECOME_PASSWORD or ANSIBLE_BECOME_PASSWORD_FILE will allow control of -passwordless-sudo as well as the input of a required password;
* ANSIBLE_INVENTORY can be used to set the value of -inventory , whilst GASCAN_DEFAULT_INVENTORY is an additional control that disabled use of the default inventory even when ANSIBLE_INVENTORY is unset.
* GASCAN_INVENTORY_CONFIG_FILE controls the path to the config file used by the dynamic inventory plugin, as well as by the standalone script that exists as both an example and for scenarios such as checking what the inventory would produce, etc

To help allow control over other default values, the following will be added:

* EDITOR  for -editor
* GASCAN_FLAG_LOG_LEVEL for -log-level
* GASCAN_FLAG_PASSWORDLESS_SUDO will allow -passwordless-sudo to be omitted, regardless of ANSIBLE_BECOME*
* GASCAN_FLAG_PLAYBOOK for -playbook so long as it is present in the bundle
* GASCAN_FLAG_SKIP_TAGS for -skip-tags
* GASCAN_FLAG_TAGS for -tags