### PR TITLE
Update container images during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ build: export GOARCH=${ARCH}
 build: export VDIR=${BUILD_DIR}/${OS}/${ARCH}/${BUILD_BASE_TAG}
 build: export VNAME=${VDIR}/${NAME}-py${PY}
 build: export CGO_ENABLED=0
-build: build_prep pack check
+build: build_prep check
 ifeq ($(DEBUG_BUILD), 1)
 	@${GO} build -o "${VNAME}" -trimpath -gcflags="all=-N -l" \
 		-ldflags="-X main.EntryPointPlaybook=${ENTRYPOINT} -X main.HeaderIdentifier=${AUTH_FIELD_1} -X main.HeaderToken=${AUTH_FIELD_2} -X main.HeaderMonitorName=${AUTH_FIELD_3}"
@@ -121,7 +121,7 @@ build_prep: export GOOS=${OS}
 build_prep: export GOARCH=${ARCH}
 build_prep: export VDIR=${BUILD_DIR}/${OS}/${ARCH}/${BUILD_BASE_TAG}
 build_prep: export VNAME=${VDIR}/ansible${PY}
-build_prep: go_generate
+build_prep: pack go_generate
 	@rm -vf "${BUILD_DIR}/gascan"
 	@cp -a "${VNAME}" "${BUILD_DIR}/ansible"
 

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ ansible: ansible_image ansible_pex
 ansible_image: export VNAME=${NAME}/${BUILD_BASE_TAG}-ansible:${VERSION}
 ansible_image:
 	@podman image exists "${VNAME}" && podman image rm "${VNAME}" || true
-	@buildah bud -f images/ansible/Containerfile --build-arg BASE="${BUILD_BASE}" \
+	@buildah bud -f images/ansible/Containerfile --pull \
+	  --build-arg BASE="${BUILD_BASE}" \
 	  --build-arg PACKAGES_OS="${PACKAGES_OS}" --build-arg PACKAGES_PIP="${PACKAGES_PIP}" \
 	  --build-arg ANSIBLE="${ANSIBLE}" --squash --no-cache --force-rm --compress --tag "${VNAME}"
 

--- a/scripts/ansible/init.sh
+++ b/scripts/ansible/init.sh
@@ -38,6 +38,7 @@ function setup_debian {
     esac
 
     apt update -qqy
+    apt upgrade -qqy
     apt install -qqy "${packages[@]}"
     apt clean -qqy
 }
@@ -58,6 +59,7 @@ function setup_redhat {
         "centos:stream9") packages+=( python3 python-wheel-wheel ); repos=( "--enablerepo=crb" );
     esac
 
+    dnf upgrade -q -y
     dnf install -y "${repos[@]}" "${packages[@]}"
     dnf clean all
 }
@@ -75,6 +77,7 @@ function setup_redhat_legacy {
     esac
 
     yum makecache -y
+    yum upgrade -q -y
     yum install -y centos-release-scl
     yum install -y "${packages[@]}"
     yum clean all


### PR DESCRIPTION
It is possible that the container images (used to build the Ansible PEX) have pending OS updates to apply, even if the latest image is present.

* Ensure container image is pulled prior to build
* Ensure that package updates are applied during build