### PR TITLE
Exit code from playbook is not passed through

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,6 @@ else
 		-ldflags="-s -w -X main.EntryPointPlaybook=${ENTRYPOINT} -X main.HeaderIdentifier=${AUTH_FIELD_1} -X main.HeaderToken=${AUTH_FIELD_2} -X main.HeaderMonitorName=${AUTH_FIELD_3}"
 endif
 	@cp -a "${VNAME}" "${BUILD_DIR}/gascan"
-	@rm -f version.go
 
 build_prep: export GOOS=${OS}
 build_prep: export GOARCH=${ARCH}

--- a/main.go
+++ b/main.go
@@ -87,6 +87,8 @@ var (
 	//go:embed scripts/dynamic-inventory/get_inventory.py
 	dynamicInventory []byte
 
+	exitCode int
+
 	isDone bool
 
 	optInDefaultOn  = map[string]bool{"": true, "true": true, "yes": true, "1": true}
@@ -372,6 +374,7 @@ func prepareHost(baseDir string, binDir string, configDir string) error {
 func main() {
 	flags()
 
+	exitCode = 0
 	isDone = false
 	tmpDir := createWorkspace()
 
@@ -405,6 +408,8 @@ func main() {
 			fmt.Println("Run ping test: ANSIBLE_CONFIG="+ansibleConfig, "PEX_SCRIPT=ansible-playbook ", Ansible, a, tp)
 			fmt.Println("Run deploy: ANSIBLE_CONFIG="+ansibleConfig, "PEX_SCRIPT=ansible-playbook ", Ansible, a, pp)
 		}
+
+		os.Exit(exitCode)
 	}()
 
 	extractBundle(bundle, tmpDir)
@@ -446,6 +451,6 @@ func main() {
 
 	if Config.Mode&deployMode > 0 {
 		a := append([]string{pp}, playArgs...)
-		isDone = RunPlaybook(ansibleConfig, a...)
+		isDone, exitCode = RunPlaybook(ansibleConfig, a...)
 	}
 }

--- a/os.go
+++ b/os.go
@@ -34,7 +34,7 @@ func createWorkspace() string {
 }
 
 // RunPlaybook via ansible-playbook
-func RunPlaybook(ansibleConfig string, args ...string) bool {
+func RunPlaybook(ansibleConfig string, args ...string) (bool, int) {
 	c := generateCommand(Ansible, args...)
 	c.Env = append(os.Environ(), "PEX_SCRIPT=ansible-playbook", fmt.Sprintf("ANSIBLE_CONFIG=%s", ansibleConfig))
 
@@ -42,10 +42,10 @@ func RunPlaybook(ansibleConfig string, args ...string) bool {
 
 	if err := c.Run(); err != nil {
 		Logger.Error("failed to execute command '%s': %s", c, err)
-		return false
+		return false, c.ProcessState.ExitCode()
 	}
 
-	return true
+	return true, 0
 }
 
 func editTemplates(path string) error {


### PR DESCRIPTION
When a playbook is executed, the exit code is not passed through and so a failure is not detectable without inspecting the output.

* Updated `os.RunPlaybook` to return a status and exit code; 2 values are returned so that there is the potential to return true even when a playbook fails, should the need arise.
* Updated `main` to use the `exitCode` in the deferred function