### PR TITLE
GAS-576 Unable to set netrc_file in config

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,6 +8,7 @@ on:
     - 'automation/**'
     - 'scripts/ansible/**'
     - scripts/dynamic-inventory/get_inventory.py
+    - scripts/connect/connect.py
 
 jobs:
   build:

--- a/scripts/connect/connect.py
+++ b/scripts/connect/connect.py
@@ -364,6 +364,8 @@ class Connect: # pylint: disable=too-many-instance-attributes
                     log().debug('Applying override for %s', k)
                     if k.replace('_', '-') not in runtime_args:
                         config[k] = v
+                    if k == 'netrc_file':
+                        config[k] = FileType('r')(v)
             log().setLevel(config['log_level'].upper())
         except (json.JSONDecodeError, OSError):
             pass


### PR DESCRIPTION
When configuring the connection tool it is not currently possible to set netrc_file due to it requiring an object.

* Fixed override of `netrc_file` to generate a `FileType` object