### PR TITLE
GAS-602 Enable inventory listing via gascan

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Usage of gascan:
         Extract the bundle to this path, use with --extract-bundle, when TMPDIR cannot execute, etc (default "/tmp")
   -generate-hash
         Generate a sha256 time-based hash
+  -get-inventory
+        Request the Ansible inventory
   -inventory string
         Set a custom inventory
   -log-level string

--- a/cli.go
+++ b/cli.go
@@ -13,6 +13,7 @@ type Flags struct {
 	Editor         string
 	EnableGodMode  bool
 	ExtractPath    string
+	GetInventory   bool
 	Inventory      string
 	LogLevel       string
 	Mode           uint
@@ -90,6 +91,7 @@ func flags() {
 	testFlag := flag.Bool("test", false, "Run the test play (ping)")
 	versionFlag := flag.Bool("version", false, "Show the version")
 
+	flag.BoolVar(&Config.GetInventory, "get-inventory", false, "Request the Ansible inventory")
 	flag.BoolVar(&Config.NoSudoPassword, "passwordless-sudo", !needsBecomePass, "The use of sudo does not require a password [GASCAN_FLAG_PASSWORDLESS_SUDO]")
 
 	flag.StringVar(&Config.Editor, "editor", defaultEditor, "Path to preferred editor [EDITOR]")
@@ -148,12 +150,19 @@ func flags() {
 	if *testFlag {
 		Config.Mode += testMode
 	}
+
 	if !*noConfigFlag && Config.Inventory == "" && optInDefaultOn[os.Getenv("GASCAN_DEFAULT_INVENTORY")] {
 		Config.Mode += configMode
 	}
+
 	if !*noDeployFlag {
 		Config.Mode += deployMode
 	}
+
+	if Config.GetInventory {
+		Config.Mode = inventoryMode
+	}
+
 	if *extractOnlyFlag {
 		Config.Mode = extractMode
 		os.Setenv("GASCAN_TEST_NOEXIT", "1")

--- a/main.go
+++ b/main.go
@@ -16,10 +16,11 @@ import (
 )
 
 const (
-	configMode  uint = 2
-	deployMode  uint = 4
-	testMode    uint = 8
-	extractMode uint = 16
+	configMode    uint = 2
+	deployMode    uint = 4
+	testMode      uint = 8
+	extractMode   uint = 16
+	inventoryMode uint = 32
 
 	extractMessage string = `
 # Add the following to your shell profile:
@@ -441,6 +442,12 @@ func main() {
 		if err := editTemplates(tpls); err != nil {
 			Logger.Fatal("unable to make the necessary configuration changes: %v", err)
 		}
+	}
+
+	if Config.Mode&inventoryMode > 0 {
+		Logger.Debug("Requesting the inventory")
+		ShowInventory(ansibleConfig, []string{"--list"}...)
+		os.Exit(0)
 	}
 
 	if Config.Mode&testMode > 0 {

--- a/os.go
+++ b/os.go
@@ -47,6 +47,21 @@ func RunPlaybook(ansibleConfig string, args ...string) (bool, int) {
 	return true, 0
 }
 
+// ShowInventory via ansible-inventory
+func ShowInventory(ansibleConfig string, args ...string) (bool, int) {
+	c := generateCommand(Ansible, args...)
+	c.Env = append(os.Environ(), "PEX_SCRIPT=ansible-inventory", fmt.Sprintf("ANSIBLE_CONFIG=%s", ansibleConfig))
+
+	Logger.Debug("Showing the inventory: %s", c.Env)
+
+	if err := c.Run(); err != nil {
+		Logger.Error("failed to execute command '%s': %s", c, err)
+		return false, c.ProcessState.ExitCode()
+	}
+
+	return true, 0
+}
+
 func editTemplates(path string) error {
 	args := append([]string{Config.Editor}, strings.Split(path, " ")...)
 	c := generateCommand("command", args...)


### PR DESCRIPTION
Enable listing the Ansible inventory without extracting any files.

* Added `GetInventory` flag to store the status of `-get-inventory`
* Added `inventoryMode` constant for use with `Config.Mode` bitwise comparisons
* Added `ShowInventory` to execute `ansible-inventory --list` when `Config.Mode&inventoryMode` and then exit