### PR TITLE
GAS-690 Add --refresh flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ARCH?=amd64
 AUTH_FIELD_1?=Auth-Id
 AUTH_FIELD_2?=Auth-Token
 AUTH_FIELD_3?=Monitor-Name
-BUILD_BASE?=quay.io/centos/centos:stream8
+BUILD_BASE?=debian:bullseye
 BUILD_DIR?=./build
 BUNDLE_VERSION?=$(shell git rev-parse HEAD)
 ENTRYPOINT?=pmm-full.yaml
@@ -50,10 +50,10 @@ ifeq ($(INSTALL_GO_LINTER), 1)
 	@cd ~ && "${GO}" install golang.org/x/lint/golint@latest
 endif
 
-all: ansible build 
+all: ansible build
 
 all_versions:
-	@printf "all_el9\nall_el8\nall_el7\nall_jammy\nall_bullseye"
+	@printf "all_el9\nall_jammy\nall_bullseye"
 
 all_el9: export BUILD_BASE=quay.io/centos/centos:stream9
 all_el9: export BUILD_BASE_TAG=centos-stream9

--- a/cli.go
+++ b/cli.go
@@ -10,6 +10,7 @@ import (
 
 // Flags provides configuration options
 type Flags struct {
+	ClearCache     bool
 	Editor         string
 	EnableGodMode  bool
 	ExtractPath    string
@@ -91,6 +92,7 @@ func flags() {
 	testFlag := flag.Bool("test", false, "Run the test play (ping)")
 	versionFlag := flag.Bool("version", false, "Show the version")
 
+	flag.BoolVar(&Config.ClearCache, "refresh", false, "Clear inventory caches to allow for a refresh")
 	flag.BoolVar(&Config.GetInventory, "get-inventory", false, "Request the Ansible inventory")
 	flag.BoolVar(&Config.NoSudoPassword, "passwordless-sudo", !needsBecomePass, "The use of sudo does not require a password [GASCAN_FLAG_PASSWORDLESS_SUDO]")
 

--- a/main.go
+++ b/main.go
@@ -444,8 +444,17 @@ func main() {
 		}
 	}
 
+	if Config.ClearCache {
+		Logger.Debug("clearing the inventory cache")
+
+		if err := clearInventoryCache(); err != nil {
+			Logger.Fatal("unable to reset the cache: %v", err)
+		}
+	}
+
 	if Config.Mode&inventoryMode > 0 {
 		Logger.Debug("Requesting the inventory")
+
 		ShowInventory(ansibleConfig, []string{"--list"}...)
 		os.Exit(0)
 	}

--- a/os_test.go
+++ b/os_test.go
@@ -77,3 +77,30 @@ func TestExtraction(t *testing.T) {
 		t.Fatalf("found foo.txt")
 	}
 }
+
+func TestClearCache(t *testing.T) {
+	var err error
+
+	EnvCachePaths = "~,~/"
+	tmpDir := ""
+
+	if err = clearInventoryCache(); err == nil {
+		t.Fatalf("expected an error for EnvCachePaths %q", EnvCachePaths)
+	}
+
+	if tmpDir, err = os.MkdirTemp(os.TempDir(), "cache1"); err != nil {
+		t.Fatalf("unable to create directory: %v", err)
+	}
+
+	EnvCachePaths = tmpDir
+
+	if tmpDir, err = os.MkdirTemp(os.TempDir(), "cache2"); err != nil {
+		t.Fatalf("unable to create directory: %v", err)
+	}
+
+	EnvCachePaths += "," + filepath.Join(tmpDir, "foobar*") + "," + tmpDir
+
+	if err = clearInventoryCache(); err != nil {
+		t.Fatalf("unexpected error for EnvCachePaths %q", EnvCachePaths)
+	}
+}


### PR DESCRIPTION
Avoid the need to clear inventory caches manually.

* Added Flags.ClearCache to save the state of --refresh
* Added EnvCachePaths to store a comma-separated set of path names, allowing for overrides at build time
* Added clearInventoryCache to perform the purge of each path in EnvCachePaths, with specific handling for a ~ prefix and * suffix
* Added TestClearCache to test clearInventoryCache logic
* Added call to clearInventoryCache during processing
* Updated Makefile to use Debian 11 as the default build, removing the now-EOL CentOS Stream 8