### PR TITLE
GAS-776 Fix ANSIBLE_BECOME_PASSWORD

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -54,7 +54,7 @@ func flags() {
 	Config.Mode = 0
 
 	envInventory := os.Getenv("ANSIBLE_INVENTORY")
-	envBecomePass := os.Getenv("ANSIBLE_BECOME_PASSWORD")
+	envBecomePass := os.Getenv("ANSIBLE_BECOME_PASS")
 	envBecomePassFile := os.Getenv("ANSIBLE_BECOME_PASSWORD_FILE")
 
 	envEditor := os.Getenv("EDITOR")


### PR DESCRIPTION
For whatever reason, whilst `ansible_become_pass` and `ansible_become_password` are both valid, when it comes to the environment variables, `ANSIBLE_BECOME_PASS` is the only one that is recognised, despite the similar one for a file being as expected, `ANSIBLE_BECOME_PASSWORD_FILE`

* Fixed lookup of Ansible env variable to look for `ANSIBLE_BECOME_PASS`