### PR TITLE
GAS-691 Add --override flag

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -115,11 +116,20 @@ func flags() {
 	flag.Func("override", "Overrides to pass to Ansible as --extra-vars", func(s string) error {
 		vals := strings.SplitN(s, "=", 2)
 
-		if len(vals) != 2 {
-			panic(fmt.Sprintf("TBD override val too short: %v from %v", vals, s))
-		}
+		if strings.HasPrefix(vals[0], "@") {
+			overrideData, err := os.ReadFile(vals[0][1:])
+			if err != nil {
+				panic(fmt.Sprintf("TBD override file read issues: %v from %s", vals, err))
+			}
 
-		Config.ExtraVars[strings.TrimSpace(vals[0])] = strings.TrimSpace(vals[1])
+			if err := json.Unmarshal(overrideData, &Config.ExtraVars); err != nil {
+				panic(fmt.Sprintf("TBD override file parsing issues: %v from %s", vals, err))
+			}
+		} else if len(vals) != 2 {
+			panic(fmt.Sprintf("TBD override val too short: %v from %v", vals, s))
+		} else {
+			Config.ExtraVars[strings.TrimSpace(vals[0])] = strings.TrimSpace(vals[1])
+		}
 
 		return nil
 	})

--- a/cli.go
+++ b/cli.go
@@ -15,6 +15,7 @@ type Flags struct {
 	EnableGodMode  bool
 	ExtraArguments []string
 	ExtractPath    string
+	ExtraVars      map[string]interface{}
 	GetInventory   bool
 	Inventory      string
 	LimitHosts     string
@@ -109,6 +110,20 @@ func flags() {
 	flag.StringVar(&Config.SkipTags, "skip-tags", envSkipTags, "Specify tags to skip for automation [GASCAN_FLAG_SKIP_TAGS]")
 	flag.StringVar(&Config.Tags, "tags", envTags, "Specify tags for automation [GASCAN_FLAG_TAGS]")
 
+	Config.ExtraVars = make(map[string]interface{})
+
+	flag.Func("override", "Overrides to pass to Ansible as --extra-vars", func(s string) error {
+		vals := strings.SplitN(s, "=", 2)
+
+		if len(vals) != 2 {
+			panic(fmt.Sprintf("TBD override val too short: %v from %v", vals, s))
+		}
+
+		Config.ExtraVars[strings.TrimSpace(vals[0])] = strings.TrimSpace(vals[1])
+
+		return nil
+	})
+
 	flag.Parse()
 
 	Config.ExtraArguments = flag.Args()
@@ -130,6 +145,8 @@ func flags() {
 		Logger.Level = errorLevel
 		Logger.Prefix = "ERROR"
 	}
+
+	Logger.Debug("Passing %v as --extra-vars", Config.ExtraVars)
 
 	if *versionFlag {
 		printVersion()

--- a/main.go
+++ b/main.go
@@ -389,6 +389,8 @@ func main() {
 	pp := filepath.Join(tmpDir, Config.Playbook)
 	tp := filepath.Join(tmpDir, "ping.yaml")
 
+	overrides := "/tmp/overrides.json"
+
 	if len(Config.Tags) > 0 {
 		playArgs = append(playArgs, "--tags", Config.Tags)
 	}
@@ -440,6 +442,16 @@ func main() {
 		}
 
 		playArgs = append(playArgs, "--inventory", inventory)
+	}
+
+	if len(Config.ExtraVars) > 0 {
+		if buff, err := json.Marshal(Config.ExtraVars); err != nil {
+			Logger.Error("Failed to convert Config.ExtraVars to JSON: %v", err)
+		} else if err := os.WriteFile(overrides, []byte(string(buff)), 0o600); err != nil {
+			Logger.Error("Failed to write JSON to file: %v", err)
+		}
+
+		playArgs = append([]string{"--extra-vars", "@" + overrides}, playArgs...)
 	}
 
 	if Config.Mode&adhocMode > 0 {


### PR DESCRIPTION
Add --override to avoid the need for unnecessary work when using a temporary override.

Requirements:
- can be used alone, or with other flags
-  can use multiple overrides
- should be passed through to Ansible as --extra-vars
- must have a value in a supported format by Ansible; JSON, YAML , or k=v, else be a JSON file to read from

